### PR TITLE
feat: rename to chama-pipeline.sh + add .chama.yml + bump v1.1.0

### DIFF
--- a/.chama.yml
+++ b/.chama.yml
@@ -1,0 +1,39 @@
+project:
+  name: "Chama"
+  description: "SDLC pipeline orchestrator for Claude Code"
+  repo: "rafaelportugal/chama"
+  language: "pt-BR"
+
+github:
+  owner: "rafaelportugal"
+  project_number: 2
+  default_branch: "main"
+  board_statuses:
+    todo: "Todo"
+    in_progress: "In Progress"
+    in_review: "In Review"
+    done: "Done"
+
+tech_stack:
+  summary: "Shell scripts + Markdown prompts"
+  components:
+    - name: "skills"
+      path: "skills/"
+      quality_gates: []
+    - name: "workflow"
+      path: "workflow/"
+      quality_gates: []
+    - name: "scripts"
+      path: "scripts/"
+      quality_gates:
+        - "bash -n scripts/*.sh"
+
+artifacts:
+  progress_dir: ".chama/progress"
+  reviews_dir: ".chama/reviews"
+
+personas:
+  - name: "Developer"
+    description: "Uses Chama to orchestrate SDLC in their projects"
+
+business_segment: "DevTools"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "chama",
       "description": "SDLC pipeline orchestrator — Idea -> Spec -> Code -> Review -> Merge",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chama",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "SDLC pipeline orchestrator — Idea -> Spec -> Code -> Review -> Merge",
   "author": {
     "name": "Rafael Portugal",

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For automated execution without manual intervention:
 chama-compose
 
 # Or directly
-bash chama/workflow/scripts/run-compose.sh
+bash chama/workflow/scripts/chama-pipeline.sh
 ```
 
 The compose orchestrator runs 5 phases per task:

--- a/agent/README.md
+++ b/agent/README.md
@@ -21,7 +21,7 @@ Isolated Docker runtime for executing AI agents (`claude` and `amp`) with elevat
         ├── prompt-compose-coder.md
         ├── prompt-compose-simplify.md
         └── scripts/
-            └── run-compose.sh
+            └── chama-pipeline.sh
 
 ## Setup
 
@@ -54,14 +54,14 @@ Credentials are persisted in the `agent-home` Docker volume.
 
 ### Option B — GitHub App (automatic, headless)
 
-Ideal for `run-compose.sh` executions without manual intervention.
+Ideal for `chama-pipeline.sh` executions without manual intervention.
 
 1. Create a GitHub App with permissions: `contents: write`, `issues: write`, `pull_requests: write`, `projects: read+write`
 2. Install the app on your repo
 3. Save the private key as `chama/agent/.gh-app-key.pem` (already in `.gitignore`)
 4. Set `GITHUB_APP_ID` in the environment
 
-The `run-compose.sh` script auto-detects the configuration and generates a `GH_TOKEN` via `gh-token`.
+The `chama-pipeline.sh` script auto-detects the configuration and generates a `GH_TOKEN` via `gh-token`.
 
 ### Comparison
 
@@ -70,7 +70,7 @@ The `run-compose.sh` script auto-detects the configuration and generates a `GH_T
 | Validity | Indefinite | 1 hour (auto-expires) |
 | Scope | Broad (all user orgs) | Restricted (app permissions) |
 | Setup | Simple — interactive login | Medium — create app + private key |
-| Best for | Local dev, personal use | Headless automation (`run-compose.sh`) |
+| Best for | Local dev, personal use | Headless automation (`chama-pipeline.sh`) |
 
 ## Shell configuration (bash / zsh)
 
@@ -108,8 +108,8 @@ chama-amp() {
   cat "$prompt_file" | chama-agentp amp --dangerously-allow-all
 }
 
-chama-compose() {
-  local compose_script="chama/workflow/scripts/run-compose.sh"
+chama-pipeline() {
+  local compose_script="chama/workflow/scripts/chama-pipeline.sh"
   if [ ! -f "$compose_script" ]; then
     echo "Compose script not found: $compose_script"
     return 1

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -17,7 +17,7 @@ Interactive commands live in `skills/` and are invoked as `/chama:init`, `/chama
 - `scripts/install-hooks.sh`: Install local git hooks.
 - `scripts/run-commit-reviewer.sh`: Trigger commit reviewer (foreground/background).
 - `scripts/run-pr-reviewer.sh`: Trigger PR reviewer (foreground/background).
-- `scripts/run-compose.sh`: Orchestrate the full 5-phase cycle.
+- `scripts/chama-pipeline.sh`: Orchestrate the full 5-phase cycle.
 
 ## Compose orchestration
 
@@ -25,13 +25,13 @@ After ideas and architecture are done, run compose to process multiple tasks:
 
 ```bash
 # Process up to 3 tasks (default)
-chama-compose
+chama-pipeline
 
 # Process up to 5 tasks, with up to 6 review rounds each
-MAX_TASKS=5 MAX_REVIEW_ROUNDS=6 chama-compose
+MAX_TASKS=5 MAX_REVIEW_ROUNDS=6 chama-pipeline
 
 # Continue even if review fails on a task
-STOP_ON_REVIEW_FAILURE=false chama-compose
+STOP_ON_REVIEW_FAILURE=false chama-pipeline
 ```
 
 The compose orchestrates 5 phases per task:

--- a/workflow/scripts/chama-pipeline.sh
+++ b/workflow/scripts/chama-pipeline.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ─── Compose Orchestrator ───────────────────────────────────────────────────
-# Orchestrates the cycle: coder → simplify → PR → pr-reviewer → review-loop
-# Usage: MAX_TASKS=3 MAX_REVIEW_ROUNDS=4 STOP_ON_REVIEW_FAILURE=true bash run-compose.sh
+# ─── Chama Pipeline ─────────────────────────────────────────────────────────
+# Orchestrates the full SDLC cycle: coder → simplify → PR → pr-reviewer → review-loop
+# Usage: MAX_TASKS=3 MAX_REVIEW_ROUNDS=4 STOP_ON_REVIEW_FAILURE=true bash chama-pipeline.sh
 # ─────────────────────────────────────────────────────────────────────────────
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
## Summary
- Rename `workflow/scripts/run-compose.sh` → `chama-pipeline.sh` for better discoverability
- Update all references across README, workflow/README, agent/README
- Rename shell alias `chama-compose` → `chama-pipeline`
- Add `.chama.yml` so the Chama project can use its own pipeline
- Create `.chama/` directories + `.gitignore` entry
- Bump version to `1.1.0`

## Test plan
- [ ] `chama-pipeline.sh` runs correctly from project root
- [ ] No remaining references to `run-compose.sh`
- [ ] `.chama.yml` is valid and `sync-board-statuses.sh` passes
- [ ] Version `1.1.0` in both `plugin.json` and `marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)