### PR TITLE
feat: [Issue #26] Phase 2 - Integração, docs e validação

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
     "email": "rafaelportugal@users.noreply.github.com"
   },
   "metadata": {
-    "description": "SDLC pipeline orchestrator — Idea -> Spec -> Code -> Review -> Merge"
+    "description": "SDLC pipeline orchestrator — Bootstrap -> Idea -> Spec -> Code -> Review -> Merge"
   },
   "plugins": [
     {
       "name": "chama",
-      "description": "SDLC pipeline orchestrator — Idea -> Spec -> Code -> Review -> Merge",
+      "description": "SDLC pipeline orchestrator — Bootstrap -> Idea -> Spec -> Code -> Review -> Merge",
       "version": "1.4.0-draft.1",
       "source": "./"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chama",
   "version": "1.4.0-draft.1",
-  "description": "SDLC pipeline orchestrator — Idea -> Spec -> Code -> Review -> Merge",
+  "description": "SDLC pipeline orchestrator — Bootstrap -> Idea -> Spec -> Code -> Review -> Merge",
   "author": {
     "name": "Rafael Portugal",
     "url": "https://github.com/rafaelportugal"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Chama is a generic SDLC pipeline orchestrator that works with any project via `.
 - `skills/` — Slash commands (interactive, invoked by user as `/chama:<skill>`)
 - `workflow/` — Headless prompts for compose/automation pipelines
 - `agent/` — Docker runtime for isolated AI agent execution
-- `templates/` — Templates used by `/chama:init` for project onboarding
+- `templates/` — Templates used by `/chama:init` and `/chama:new-project` for project onboarding and bootstrap
 - `scripts/` — Utility scripts (GitHub label setup, etc.)
 
 ## Key patterns
@@ -24,12 +24,20 @@ Chama is a generic SDLC pipeline orchestrator that works with any project via `.
 ## Command flow
 
 ```
-/chama:init       -> onboard project (.chama.yml, labels, project, .chama/templates/)
-/chama:ideas      -> brainstorm -> GitHub Issue (label: idea)
-/chama:architect  -> idea Issue -> Spec Issue + phase Issues (reads knowledge_paths + spec template)
-/chama:code       -> phase Issue (Todo) -> implement -> PR
+/chama:new-project -> guided bootstrap: idea -> synthesis -> local foundation (.chama.yml, CLAUDE.md, docs/, structure)
+       ↓ (optional)
+/chama:init        -> onboard project (GitHub labels, board, project number, .chama/templates/)
+       ↓
+/chama:ideas       -> brainstorm -> GitHub Issue (label: idea)
+       ↓
+/chama:architect   -> idea Issue -> Spec Issue + phase Issues (reads knowledge_paths + spec template)
+       ↓
+/chama:code        -> phase Issue (Todo) -> implement -> PR
+       ↓
 /chama:review-loop -> PR comments -> fix/respond -> merge
 ```
+
+**Note:** `/chama:new-project` is local-first — it generates project foundation on the local filesystem without requiring GitHub. It composes with `/chama:init` (which handles GitHub setup) but does not depend on it. Projects can start with either command depending on whether the project already exists.
 
 ## Versioning
 


### PR DESCRIPTION
Closes #26

## Spec
- #24

## Summary
Integra o `/chama:new-project` ao pipeline existente do Chama: atualiza command flow no CLAUDE.md, descrição do plugin, e valida compatibilidade com todos os comandos existentes.

## Changes
- **CLAUDE.md**: command flow atualizado com `new-project` como primeiro passo (opcional), nota sobre local-first, referência a templates
- **plugin.json / marketplace.json**: descrição atualizada para incluir "Bootstrap" no pipeline

## Compatibility validation
- **init**: pre-check já detecta `.chama.yml` existente → pula para GitHub setup. `project_number` comentado é preenchido pelo init. ✅
- **ideas**: lê `project.repo`, `project.language`, `personas`, `business_segment` — todos gerados pelo new-project. ✅
- **architect**: lê mesmos campos + `knowledge_paths` (backward compatible se ausente) + `project_number` (necessário para board → requer init antes). ✅
- **code / review-loop**: herdam benefício de quality gates e CLAUDE.md melhor. Sem dependência direta. ✅
- **Regressão**: nenhum skill existente foi modificado.

## Checklist
- [x] CLAUDE.md atualizado com command flow incluindo `/chama:new-project`
- [x] Pipeline completo documentado: `new-project → init → ideas → architect → code → review-loop`
- [x] Compatibilidade init verificada (aceita `.chama.yml` sem `project_number`)
- [x] Compatibilidade ideas verificada (campos preenchidos são suficientes)
- [x] Compatibilidade architect verificada (contexto gerado é suficiente, `project_number` requer init)
- [x] Descrição do plugin atualizada

🤖 Generated with [Claude Code](https://claude.com/claude-code)