### PR TITLE
feat: [Issue #48] make bump-version com changelog via LLM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,44 +41,25 @@ Chama is a generic SDLC pipeline orchestrator that works with any project via `.
 
 ## Versioning
 
-This project uses automatic versioning tied to the Spec lifecycle. The version in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` always reflects the current pipeline state.
+**Schema:** `MAJOR.MINOR.PATCH` (standard semver).
 
-**Schema:** `MAJOR.MINOR.PATCH-draft.N` (semver + draft suffix). Draft versions indicate work-in-progress; stable versions (no suffix) indicate a completed Spec.
+Version bumps are manual and controlled by the developer via `make bump-version`. Multiple Specs can run in parallel without version conflicts.
 
-**Constraint:** Only one Spec may be active at a time. Do not start a new Spec while another has draft versions in progress.
+### How to bump
 
-### When to bump
+Run `make bump-version`. The command will:
+1. Show current version and commits since last bump
+2. Generate a categorized changelog via LLM (`claude --print`)
+3. Ask for bump type (patch/minor/major)
+4. Ask for confirmation
+5. Update version files + CHANGELOG.md + commit
 
-#### 1. Architect creates a Spec (`/chama:architect`)
-
-1. Read the current stable version (ignore any `-draft.*` suffix) from `.claude-plugin/plugin.json`.
-2. Increment the minor: if stable is `1.2.0`, next minor is `1.3.0`.
-3. Add the field `**Version:** X.Y.x` (e.g., `**Version:** 1.3.x`) to the Spec issue body.
-4. Run: `scripts/bump-version.sh X.Y.0-draft.0` (e.g., `scripts/bump-version.sh 1.3.0-draft.0`).
-
-#### 2. Phase completed (`/chama:review-loop`)
-
-When a phase is moved to Done:
-
-1. Count the total number of closed/Done phases for this Spec (N).
-2. Run: `scripts/bump-version.sh X.Y.0-draft.N` (e.g., if 2 phases are done: `scripts/bump-version.sh 1.3.0-draft.2`).
-
-#### 3. Spec closed (last phase completed)
-
-When the last phase of a Spec is completed and the Spec is auto-closed:
-
-1. Run: `scripts/bump-version.sh X.Y.0` (e.g., `scripts/bump-version.sh 1.3.0`) — no draft suffix.
-
-### Calculation rules
-
-- The **minor** is always based on the latest stable version (without `-draft.*` suffix). To find it: read the version from `plugin.json`, strip any `-draft.*` suffix, then increment minor.
-- The **draft count** (N) equals the number of phases with status Done for the current Spec.
-- The **patch** is always `0` (patch bumps are not used in the Spec lifecycle).
-- Rollback: reopening a phase does not decrement the version.
+If the `claude` CLI is not available, falls back to a plain commit list.
 
 ### Script reference
 
-`scripts/bump-version.sh <version>` — reads `versioning.files` from `.chama.yml`, updates the `version` field in each configured JSON file, and creates a commit (`chore: bump version to <version>`). The script is idempotent: running it twice with the same version produces no error and no duplicate commit.
+- `make bump-version` — interactive bump with LLM changelog (entry point)
+- `scripts/bump-version.sh <version> [--changelog "message"]` — low-level: updates version files from `.chama.yml`, optionally prepends CHANGELOG.md entry, creates commit. Idempotent.
 
 ## When editing this plugin
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ If the `claude` CLI is not available, falls back to a plain commit list.
 ### Script reference
 
 - `make bump-version` — interactive bump with LLM changelog (entry point)
-- `scripts/bump-version.sh <version> [--changelog "message"]` — low-level: updates version files from `.chama.yml`, optionally prepends CHANGELOG.md entry, creates commit. Idempotent.
+- `scripts/bump-version.sh <version> [--changelog "message"]` — low-level: updates version files from `.chama.yml`, optionally prepends CHANGELOG.md entry, creates commit. Idempotent (skips if version already matches and changelog entry already exists).
 
 ## When editing this plugin
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: bump-version
+
+bump-version:
+	@bash scripts/make-bump-version.sh

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -17,7 +17,12 @@ shift || true
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --changelog)
-      CHANGELOG_MSG="${2:-}"
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --changelog requires a non-empty message argument." >&2
+        echo "Usage: $0 <new-version> [--changelog \"message\"]" >&2
+        exit 1
+      fi
+      CHANGELOG_MSG="$2"
       shift 2
       ;;
     *)
@@ -98,18 +103,26 @@ done
 
 # ─── Update CHANGELOG.md ────────────────────────────────────────────────────
 
-if [[ -n "$CHANGELOG_MSG" ]] && [[ -f "CHANGELOG.md" ]]; then
-  TODAY=$(date +%Y-%m-%d)
-  TMP_FILE=$(mktemp)
-  # Keep the "# Changelog" header
-  head -1 CHANGELOG.md > "$TMP_FILE"
-  # Insert new entry
-  printf '\n## [%s] - %s\n\n%s\n' "$NEW_VERSION" "$TODAY" "$CHANGELOG_MSG" >> "$TMP_FILE"
-  # Append rest of file (skip first line)
-  tail -n +2 CHANGELOG.md >> "$TMP_FILE"
-  mv "$TMP_FILE" CHANGELOG.md
-  echo "  Updated CHANGELOG.md with entry for $NEW_VERSION"
-  CHANGED=true
+if [[ -n "$CHANGELOG_MSG" ]]; then
+  if [[ ! -f "CHANGELOG.md" ]]; then
+    echo "ERROR: --changelog was provided but CHANGELOG.md does not exist." >&2
+    echo "Create a CHANGELOG.md with a '# Changelog' header before retrying." >&2
+    exit 1
+  fi
+
+  # Skip if entry already exists (idempotent)
+  if grep -q "^## \[$NEW_VERSION\] - " CHANGELOG.md; then
+    echo "  CHANGELOG.md already has entry for $NEW_VERSION, skipping."
+  else
+    TODAY=$(date +%Y-%m-%d)
+    TMP_FILE=$(mktemp)
+    head -1 CHANGELOG.md > "$TMP_FILE"
+    printf '\n## [%s] - %s\n\n%s\n' "$NEW_VERSION" "$TODAY" "$CHANGELOG_MSG" >> "$TMP_FILE"
+    tail -n +2 CHANGELOG.md >> "$TMP_FILE"
+    mv "$TMP_FILE" CHANGELOG.md
+    echo "  Updated CHANGELOG.md with entry for $NEW_VERSION"
+    CHANGED=true
+  fi
 fi
 
 # ─── Commit ──────────────────────────────────────────────────────────────────

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -3,14 +3,33 @@ set -euo pipefail
 
 # ─── Bump Version ────────────────────────────────────────────────────────────
 # Updates the version field in all files listed in .chama.yml versioning.files.
-# Usage: scripts/bump-version.sh <new-version>
+# Optionally prepends an entry to CHANGELOG.md.
+#
+# Usage: scripts/bump-version.sh <new-version> [--changelog "message"]
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ─── Parse arguments ─────────────────────────────────────────────────────────
+
 NEW_VERSION="${1:-}"
+CHANGELOG_MSG=""
+
+shift || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --changelog)
+      CHANGELOG_MSG="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
 
 if [[ -z "$NEW_VERSION" ]]; then
-  echo "Usage: $0 <new-version>" >&2
-  echo "Example: $0 1.3.0-draft.0" >&2
+  echo "Usage: $0 <new-version> [--changelog \"message\"]" >&2
+  echo "Example: $0 1.6.0 --changelog \"### Added\n- New feature\"" >&2
   exit 1
 fi
 
@@ -77,12 +96,34 @@ for i in $(seq 0 $((FILE_COUNT - 1))); do
   CHANGED=true
 done
 
+# ─── Update CHANGELOG.md ────────────────────────────────────────────────────
+
+if [[ -n "$CHANGELOG_MSG" ]] && [[ -f "CHANGELOG.md" ]]; then
+  TODAY=$(date +%Y-%m-%d)
+  TMP_FILE=$(mktemp)
+  # Keep the "# Changelog" header
+  head -1 CHANGELOG.md > "$TMP_FILE"
+  # Insert new entry
+  printf '\n## [%s] - %s\n\n%s\n' "$NEW_VERSION" "$TODAY" "$CHANGELOG_MSG" >> "$TMP_FILE"
+  # Append rest of file (skip first line)
+  tail -n +2 CHANGELOG.md >> "$TMP_FILE"
+  mv "$TMP_FILE" CHANGELOG.md
+  echo "  Updated CHANGELOG.md with entry for $NEW_VERSION"
+  CHANGED=true
+fi
+
+# ─── Commit ──────────────────────────────────────────────────────────────────
+
 if [[ "$CHANGED" == "true" ]]; then
-  # Stage and commit only the versioned files
+  # Stage versioned files
   for i in $(seq 0 $((FILE_COUNT - 1))); do
     FILE_PATH=$(yq ".versioning.files[$i].path" .chama.yml)
     git add "$FILE_PATH"
   done
+  # Stage changelog if updated
+  if [[ -n "$CHANGELOG_MSG" ]] && [[ -f "CHANGELOG.md" ]]; then
+    git add CHANGELOG.md
+  fi
   git commit -m "chore: bump version to $NEW_VERSION"
   echo "Committed: chore: bump version to $NEW_VERSION"
 else

--- a/scripts/make-bump-version.sh
+++ b/scripts/make-bump-version.sh
@@ -45,7 +45,13 @@ echo ""
 
 # ─── Collect commits since last bump ────────────────────────────────────────
 
-LAST_BUMP_COMMIT=$(git log --first-parent --grep="chore: bump version" -1 --format="%H" 2>/dev/null || true)
+# Find last stable version bump (ignore draft bumps for migration)
+LAST_BUMP_COMMIT=$(git log --first-parent --grep="chore: bump version to [0-9]*\.[0-9]*\.[0-9]*$" --extended-regexp -1 --format="%H" 2>/dev/null || true)
+
+# Fallback: any bump commit if no stable found
+if [[ -z "$LAST_BUMP_COMMIT" ]]; then
+  LAST_BUMP_COMMIT=$(git log --first-parent --grep="chore: bump version" -1 --format="%H" 2>/dev/null || true)
+fi
 
 if [[ -n "$LAST_BUMP_COMMIT" ]]; then
   COMMITS=$(git log --oneline "${LAST_BUMP_COMMIT}..HEAD" 2>/dev/null || true)
@@ -135,13 +141,21 @@ echo "Bump type:"
 echo "  1) patch → $MAJOR.$MINOR.$((PATCH + 1))"
 echo "  2) minor → $MAJOR.$((MINOR + 1)).0"
 echo "  3) major → $((MAJOR + 1)).0.0"
+echo "  4) custom version"
 echo ""
-read -r -p "Choose [1/2/3]: " BUMP_CHOICE
+read -r -p "Choose [1/2/3/4]: " BUMP_CHOICE
 
 case "$BUMP_CHOICE" in
   1) NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))" ;;
   2) NEW_VERSION="$MAJOR.$((MINOR + 1)).0" ;;
   3) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+  4)
+    read -r -p "Enter version: " NEW_VERSION
+    if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "Invalid version format. Expected: X.Y.Z"
+      exit 1
+    fi
+    ;;
   *)
     echo "Invalid choice. Aborting."
     exit 1

--- a/scripts/make-bump-version.sh
+++ b/scripts/make-bump-version.sh
@@ -45,7 +45,7 @@ echo ""
 
 # ─── Collect commits since last bump ────────────────────────────────────────
 
-LAST_BUMP_COMMIT=$(git log --oneline --grep="chore: bump version" -1 --format="%H" 2>/dev/null || true)
+LAST_BUMP_COMMIT=$(git log --first-parent --grep="chore: bump version" -1 --format="%H" 2>/dev/null || true)
 
 if [[ -n "$LAST_BUMP_COMMIT" ]]; then
   COMMITS=$(git log --oneline "${LAST_BUMP_COMMIT}..HEAD" 2>/dev/null || true)
@@ -109,6 +109,13 @@ echo "────────────────────────�
 echo "$CHANGELOG"
 echo "─────────────────────────────────────────"
 echo ""
+
+# ─── Verify interactive terminal ─────────────────────────────────────────────
+
+if [[ ! -t 0 ]]; then
+  echo "ERROR: This script requires an interactive terminal." >&2
+  exit 1
+fi
 
 # ─── Ask for bump type ───────────────────────────────────────────────────────
 

--- a/scripts/make-bump-version.sh
+++ b/scripts/make-bump-version.sh
@@ -90,18 +90,25 @@ Commits:
 $COMMITS"
 fi
 
+fallback_changelog() {
+  printf '%s' "$COMMITS" | sed 's/^[a-f0-9]* /- /'
+}
+
 if command -v claude >/dev/null 2>&1; then
   echo "Generating changelog via LLM..."
   echo ""
-  CHANGELOG=$(echo "$LLM_PROMPT" | claude --print 2>/dev/null || true)
+  LLM_ERR=$(mktemp)
+  CHANGELOG=$(printf '%s' "$LLM_PROMPT" | claude --print 2>"$LLM_ERR" || true)
 
   if [[ -z "$CHANGELOG" ]]; then
     echo "WARNING: LLM generation failed. Using commit list as fallback."
-    CHANGELOG=$(echo "$COMMITS" | sed 's/^[a-f0-9]* /- /')
+    [[ -s "$LLM_ERR" ]] && echo "  Reason: $(cat "$LLM_ERR")"
+    CHANGELOG=$(fallback_changelog)
   fi
+  rm -f "$LLM_ERR"
 else
   echo "claude CLI not found. Using commit list as fallback."
-  CHANGELOG=$(echo "$COMMITS" | sed 's/^[a-f0-9]* /- /')
+  CHANGELOG=$(fallback_changelog)
 fi
 
 echo "Generated changelog:"

--- a/scripts/make-bump-version.sh
+++ b/scripts/make-bump-version.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── Make Bump Version ──────────────────────────────────────────────────────
+# Interactive version bump with LLM-generated changelog.
+# Called by: make bump-version
+#
+# Flow: collect commits → generate changelog via LLM → confirm → bump
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ─── Pre-checks ──────────────────────────────────────────────────────────────
+
+for cmd in jq yq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: '$cmd' is required but not installed." >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f ".chama.yml" ]]; then
+  echo "ERROR: .chama.yml not found in current directory." >&2
+  exit 1
+fi
+
+ENABLED=$(yq '.versioning.enabled // false' .chama.yml 2>/dev/null)
+if [[ "$ENABLED" != "true" ]]; then
+  echo "ERROR: versioning is not enabled in .chama.yml." >&2
+  exit 1
+fi
+
+# ─── Read current version ───────────────────────────────────────────────────
+
+VERSION_FILE=$(yq '.versioning.files[0].path' .chama.yml 2>/dev/null)
+VERSION_FILTER=$(yq '.versioning.files[0].jq_filter' .chama.yml 2>/dev/null)
+CURRENT_VERSION=$(jq -r "$VERSION_FILTER // empty" "$VERSION_FILE" 2>/dev/null)
+
+if [[ -z "$CURRENT_VERSION" ]]; then
+  echo "ERROR: Could not read current version from $VERSION_FILE" >&2
+  exit 1
+fi
+
+echo ""
+echo "Current version: $CURRENT_VERSION"
+echo ""
+
+# ─── Collect commits since last bump ────────────────────────────────────────
+
+LAST_BUMP_COMMIT=$(git log --oneline --grep="chore: bump version" -1 --format="%H" 2>/dev/null || true)
+
+if [[ -n "$LAST_BUMP_COMMIT" ]]; then
+  COMMITS=$(git log --oneline "${LAST_BUMP_COMMIT}..HEAD" 2>/dev/null || true)
+else
+  COMMITS=$(git log --oneline 2>/dev/null || true)
+fi
+
+if [[ -z "$COMMITS" ]]; then
+  echo "No changes since last version bump. Nothing to do."
+  exit 0
+fi
+
+echo "Commits since last bump:"
+echo "$COMMITS" | sed 's/^/  /'
+echo ""
+
+# ─── Generate changelog via LLM ─────────────────────────────────────────────
+
+LANG_CONFIG=$(yq '.project.language // "pt-BR"' .chama.yml 2>/dev/null)
+
+if [[ "$LANG_CONFIG" == "pt-BR" ]]; then
+  LLM_PROMPT="Analise os commits abaixo e gere um changelog no formato Keep a Changelog (https://keepachangelog.com).
+Categorias: Added, Changed, Fixed, Removed (use apenas as que se aplicam).
+Escreva em português (pt-BR).
+Seja descritivo mas conciso — cada item em 1-2 linhas.
+Agrupe itens relacionados.
+NÃO inclua o header ## [version] - date, apenas as categorias e itens.
+NÃO inclua explicações ou comentários, apenas o changelog.
+
+Commits:
+$COMMITS"
+else
+  LLM_PROMPT="Analyze the commits below and generate a changelog in Keep a Changelog format (https://keepachangelog.com).
+Categories: Added, Changed, Fixed, Removed (use only applicable ones).
+Write in English.
+Be descriptive but concise — each item in 1-2 lines.
+Group related items.
+Do NOT include the header ## [version] - date, only categories and items.
+Do NOT include explanations or comments, only the changelog.
+
+Commits:
+$COMMITS"
+fi
+
+if command -v claude >/dev/null 2>&1; then
+  echo "Generating changelog via LLM..."
+  echo ""
+  CHANGELOG=$(echo "$LLM_PROMPT" | claude --print 2>/dev/null || true)
+
+  if [[ -z "$CHANGELOG" ]]; then
+    echo "WARNING: LLM generation failed. Using commit list as fallback."
+    CHANGELOG=$(echo "$COMMITS" | sed 's/^[a-f0-9]* /- /')
+  fi
+else
+  echo "claude CLI not found. Using commit list as fallback."
+  CHANGELOG=$(echo "$COMMITS" | sed 's/^[a-f0-9]* /- /')
+fi
+
+echo "Generated changelog:"
+echo "─────────────────────────────────────────"
+echo "$CHANGELOG"
+echo "─────────────────────────────────────────"
+echo ""
+
+# ─── Ask for bump type ───────────────────────────────────────────────────────
+
+CLEAN_VERSION=$(echo "$CURRENT_VERSION" | sed 's/-draft\..*//')
+MAJOR=$(echo "$CLEAN_VERSION" | cut -d. -f1)
+MINOR=$(echo "$CLEAN_VERSION" | cut -d. -f2)
+PATCH=$(echo "$CLEAN_VERSION" | cut -d. -f3)
+
+echo "Bump type:"
+echo "  1) patch → $MAJOR.$MINOR.$((PATCH + 1))"
+echo "  2) minor → $MAJOR.$((MINOR + 1)).0"
+echo "  3) major → $((MAJOR + 1)).0.0"
+echo ""
+read -r -p "Choose [1/2/3]: " BUMP_CHOICE
+
+case "$BUMP_CHOICE" in
+  1) NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+  2) NEW_VERSION="$MAJOR.$((MINOR + 1)).0" ;;
+  3) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+  *)
+    echo "Invalid choice. Aborting."
+    exit 1
+    ;;
+esac
+
+echo ""
+echo "Will bump: $CURRENT_VERSION → $NEW_VERSION"
+read -r -p "Confirm? [Y/n]: " CONFIRM
+
+if [[ "$CONFIRM" =~ ^[Nn] ]]; then
+  echo "Bump cancelled. No changes made."
+  exit 0
+fi
+
+# ─── Execute bump ───────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/bump-version.sh" "$NEW_VERSION" --changelog "$CHANGELOG"
+
+echo ""
+echo "Done! Run 'git push' to publish."


### PR DESCRIPTION
Closes #48

## Spec
- #47

## Summary
Substitui o versionamento draft-based por `make bump-version` — comando manual que gera changelog via LLM e bumpa a versão com confirmação do developer.

### O que muda
- `scripts/bump-version.sh` ganha flag `--changelog "msg"` que prepende entry no CHANGELOG.md
- `scripts/make-bump-version.sh` (novo): coleta commits desde último bump, chama `claude --print` para gerar changelog categorizado, pede confirmação, executa bump
- `Makefile` (novo): target `bump-version` como entry point
- `CLAUDE.md`: seção Versioning reescrita — sem drafts, sem constraint "only one Spec", documenta `make bump-version`

### O que NÃO muda
- Nenhuma skill do plugin (review-loop, architect, code)
- `bump-version.sh` sem `--changelog` mantém comportamento original

## Checklist
- [x] `bump-version.sh` com `--changelog` prepende entry no CHANGELOG.md
- [x] `bump-version.sh` sem `--changelog` não toca CHANGELOG.md
- [x] `bash -n scripts/bump-version.sh` passa
- [x] `bash -n scripts/make-bump-version.sh` passa
- [x] `make bump-version` existe e chama o script
- [x] Fallback quando `claude` CLI não disponível
- [x] CLAUDE.md sem drafts nem constraint "only one Spec"
- [x] CLAUDE.md documenta `make bump-version`