### PR TITLE
feat: [Issue #52] README.md + LICENSE no /chama:new-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chama
 
-**SDLC pipeline orchestrator for Claude Code** — Idea -> Spec -> Code -> Review -> Merge.
+**SDLC pipeline orchestrator for Claude Code** — Bootstrap -> Idea -> Spec -> Code -> Review -> Merge.
 
 Chama is a Claude Code plugin that brings a full development lifecycle workflow to any project. Configure once with `.chama.yml` and `CLAUDE.md`, then use slash commands to drive your development.
 
@@ -18,18 +18,15 @@ The name "chama" combines fire with the act of "calling/invoking" — perfect fo
 /plugin install chama@chama
 ```
 
-### 2. Initialize your project
+### 2. Bootstrap or onboard your project
 
 ```
+# Option A: Create a new project from scratch (local-first)
+/chama:new-project
+
+# Option B: Onboard an existing project (GitHub setup)
 /chama:init
 ```
-
-This will:
-- Ask project details (name, repo, tech stack, components, quality gates)
-- Create `.chama.yml` in your project root
-- Generate `CLAUDE.md` if it doesn't exist
-- Set up GitHub labels (`idea`, `spec`, `phase`)
-- Configure GitHub Project
 
 ### 3. Start building
 
@@ -44,11 +41,31 @@ This will:
 
 | Command | Description |
 |---------|-------------|
-| `/chama:init` | Project onboarding — creates `.chama.yml`, labels, project |
+| `/chama:new-project` | Guided bootstrap — idea -> synthesis -> local foundation (`.chama.yml`, `CLAUDE.md`, `README.md`, `LICENSE`, `docs/`) |
+| `/chama:init` | Project onboarding — creates `.chama.yml`, GitHub labels, project board |
 | `/chama:ideas` | Ideas studio — brainstorm with Product Lead + Designer personas |
 | `/chama:architect` | Idea -> Spec + phases (all as GitHub Issues) |
 | `/chama:code` | Execute next Todo task with quality gates |
 | `/chama:review-loop` | Handle PR comments in loop, scoped by Spec |
+| `/chama:gate-check` | Run Critical Gate analysis on working tree or specific commit |
+
+## Command Flow
+
+```
+/chama:new-project -> guided bootstrap: idea -> synthesis -> local foundation
+       | (optional)
+/chama:init        -> onboard project (GitHub labels, board, project number)
+       |
+/chama:ideas       -> brainstorm -> GitHub Issue (label: idea)
+       |
+/chama:architect   -> idea Issue -> Spec Issue + phase Issues
+       |
+/chama:code        -> phase Issue (Todo) -> implement -> PR
+       |
+/chama:review-loop -> PR comments -> fix/respond -> merge
+```
+
+**Note:** `/chama:new-project` is local-first — it generates project foundation on the local filesystem without requiring GitHub. It composes with `/chama:init` (which handles GitHub setup) but does not depend on it.
 
 ## Configuration
 
@@ -66,7 +83,7 @@ project:
 github:
   owner: "owner"
   project_number: 1
-  default_branch: "main"             # "main", "dev", etc.
+  default_branch: "main"
   board_statuses:                    # optional — customize to match your board
     todo: "Todo"
     in_progress: "In Progress"
@@ -95,6 +112,26 @@ personas:
   - name: "Admin"
     description: "System administrator"
 
+# knowledge_paths:                  # optional — feeds domain docs into /chama:architect
+#   - "docs/"
+
+critical_gates:
+  enabled: true
+  fail_mode: open
+  severity_block:
+    - CRITICAL
+    - HIGH
+  scan_points:
+    - pre_commit
+    - pre_merge
+
+versioning:
+  enabled: true
+  strategy: "spec-lifecycle"
+  files:
+    - path: ".claude-plugin/plugin.json"
+      jq_filter: ".version"
+
 business_segment: "SaaS"
 ```
 
@@ -106,6 +143,33 @@ CHAMA_OWNER="owner"
 CHAMA_PROJECT_NUMBER="1"
 CHAMA_DEFAULT_BRANCH="main"
 ```
+
+## Features
+
+### Knowledge Paths
+
+Add `knowledge_paths` to `.chama.yml` to feed domain docs (`.md`, `.yml`, `.yaml`, `.txt`) into the architect. Progressive limits apply:
+- **10 files / 100KB**: read all, no alerts
+- **11-15 files / 101-200KB**: read all + warning
+- **>15 files / >200KB**: skip with error
+
+### Custom Spec Template
+
+Override the default spec template by placing your own at `.chama/templates/spec.md`. The architect will use it instead of the built-in default.
+
+### Critical Gate
+
+Pre-commit and pre-merge safety checks for destructive operations. Scans diffs for database drops, secret exposure, infra changes, and ~40 built-in rules across 6 domains. Run standalone with `/chama:gate-check`.
+
+### Versioning
+
+Manual bump with LLM-generated changelog:
+
+```bash
+make bump-version
+```
+
+Shows commits since last bump, generates a categorized changelog via `claude --print`, asks for bump type (patch/minor/major), and commits.
 
 ## GitHub Issues as Storage
 
@@ -122,6 +186,7 @@ Instead of local `.md` files, ideas and Specs live as GitHub Issues:
 /chama:ideas      -> creates Issue label:idea
 /chama:architect  -> reads idea Issue -> creates spec + phase Issues
 /chama:code       -> finds phase Issue status:Todo -> implements, creates PR
+/chama:review-loop -> handles PR comments -> merges -> moves to Done
 ```
 
 ## Headless / Compose Mode
@@ -133,7 +198,7 @@ For automated execution without manual intervention.
 Add the `chama-compose` function to your `~/.zshrc` (or `~/.bashrc`):
 
 ```bash
-# ─── Chama SDLC Pipeline ─────────────────────────────────────────────────────
+# --- Chama SDLC Pipeline ---
 _chama_find_plugin() {
   local root_dir
   root_dir="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -217,27 +282,39 @@ chama/
 │   ├── plugin.json              # Plugin manifest
 │   └── marketplace.json         # Marketplace definition
 ├── skills/                      # Slash commands (interactive)
-│   ├── init/SKILL.md
-│   ├── ideas/SKILL.md
-│   ├── architect/SKILL.md
-│   ├── code/SKILL.md
-│   └── review-loop/SKILL.md
+│   ├── new-project/SKILL.md     # Guided project bootstrap
+│   ├── init/SKILL.md            # Project onboarding
+│   ├── ideas/SKILL.md           # Ideas studio
+│   ├── architect/SKILL.md       # Idea -> Spec + phases
+│   ├── code/SKILL.md            # Task executor
+│   ├── review-loop/SKILL.md     # PR comment handler
+│   └── gate-check/SKILL.md      # Critical Gate standalone
 ├── workflow/                    # Headless prompts + scripts
 │   ├── prompt-compose-coder.md
 │   ├── prompt-compose-simplify.md
 │   ├── prompt-commit-reviewer.md
 │   ├── prompt-pr-reviewer.md
-│   ├── prompt-generate-specs.md
+│   ├── prompt-review-loop.md
 │   └── scripts/
 ├── agent/                       # Docker runtime
 │   ├── Dockerfile
 │   ├── docker-compose.yml
 │   └── README.md
-├── templates/                   # Templates for /chama:init
+├── templates/                   # Templates for bootstrap/init
 │   ├── chama.yml.template
-│   └── CLAUDE.md.template
+│   ├── CLAUDE.md.template
+│   ├── PROJECT_BRIEF.md.template
+│   ├── README.md.template
+│   ├── spec.md.default
+│   └── critical-gates.yml.default
 ├── scripts/
-│   └── setup-github-project.sh
+│   ├── bump-version.sh          # Version bump engine
+│   ├── make-bump-version.sh     # Interactive bump with LLM changelog
+│   ├── run-critical-gate.sh     # Critical Gate engine
+│   ├── resolve-spec-template.sh # Spec template resolver
+│   ├── sync-board-statuses.sh   # Board status validator
+│   └── setup-github-project.sh  # GitHub project setup
+├── Makefile                     # make bump-version
 └── LICENSE
 ```
 

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -14,7 +14,7 @@ Read `project.language` from `.chama.yml` if it already exists. Otherwise, ask t
 The flow has 5 stages:
 1. **Discovery** — User provides a free-form prompt describing the project
 2. **Adaptive Questions** — 0-5 questions based on prompt richness to fill gaps
-3. **Synthesis** — Structured synthesis with 10 mandatory fields, shown for approval
+3. **Synthesis** — Structured synthesis with 11 mandatory fields, shown for approval
 4. **Generation** — Local artifact generation (`.chama.yml`, `CLAUDE.md`, `docs/PROJECT_BRIEF.md`, etc.)
 5. **Summary** — Tree of created artifacts + optional next steps
 
@@ -28,6 +28,8 @@ Before starting, detect the current state:
 [ -f "CLAUDE.md" ] && echo "EXISTING: CLAUDE.md"
 [ -f "docs/PROJECT_BRIEF.md" ] && echo "EXISTING: docs/PROJECT_BRIEF.md"
 [ -d ".chama/templates" ] && [ -f ".chama/templates/spec.md" ] && echo "EXISTING: .chama/templates/spec.md"
+[ -f "README.md" ] && echo "EXISTING: README.md"
+[ -f "LICENSE" ] && echo "EXISTING: LICENSE"
 [ -d ".git" ] && echo "GIT: initialized" || echo "GIT: not initialized"
 ```
 
@@ -42,10 +44,10 @@ Read it fully before proceeding to Stage 2.
 
 ## Stage 2 — Adaptive Questions
 
-Analyze the prompt against the **10 mandatory fields** of the minimum contract (see Stage 3). For each field, determine if the prompt provides enough information to fill it.
+Analyze the prompt against the **11 mandatory fields** of the minimum contract (see Stage 3). For each field, determine if the prompt provides enough information to fill it.
 
 **Question count rules (field coverage is primary, word count is fallback):**
-- Prompt covers all 10 fields clearly → **0 questions** (skip to Stage 3)
+- Prompt covers all 11 fields clearly → **0 questions** (skip to Stage 3)
 - Prompt covers most fields (7-9) → **1-2 questions** for missing fields
 - Prompt covers some fields (4-6) → **3-4 questions** for missing fields
 - Prompt covers few fields (0-3) → **5 questions** for the most critical gaps
@@ -63,9 +65,9 @@ Analyze the prompt against the **10 mandatory fields** of the minimum contract (
 
 ## Stage 3 — Synthesis
 
-Build a structured synthesis with exactly **10 mandatory fields**. Display it for explicit user approval.
+Build a structured synthesis with exactly **11 mandatory fields**. Display it for explicit user approval.
 
-### Minimum Contract (10 fields)
+### Minimum Contract (11 fields)
 
 | # | Field | Maps to |
 |---|-------|---------|
@@ -79,6 +81,19 @@ Build a structured synthesis with exactly **10 mandatory fields**. Display it fo
 | 8 | **Personas** (name + description) | `personas[]` in `.chama.yml` |
 | 9 | **Business segment** | `business_segment` in `.chama.yml` |
 | 10 | **Directory structure** | Drives directory creation |
+| 11 | **License** | `LICENSE` file + `README.md` section |
+
+#### License options
+
+Present the license options with a brief explanation of each:
+
+1. **MIT** — permissiva, uso livre, sem restrições
+2. **Apache 2.0** — permissiva + proteção de patentes
+3. **GPL v3** — copyleft, derivados devem ser open source
+4. **Proprietary** — all rights reserved, código privado
+5. **Nenhuma** — não criar arquivo LICENSE
+
+If the user does not specify a license preference in their prompt, ask during Stage 2 (Adaptive Questions). Default suggestion: MIT for open source projects, Proprietary for private projects.
 
 **Rules:**
 - Fields that cannot be inferred from the prompt + answers MUST be marked as **"a definir"** — never omit a field silently.
@@ -133,6 +148,7 @@ Read the following templates as structural reference (if found):
 - `$CHAMA_TEMPLATES/chama.yml.template`
 - `$CHAMA_TEMPLATES/CLAUDE.md.template`
 - `$CHAMA_TEMPLATES/PROJECT_BRIEF.md.template`
+- `$CHAMA_TEMPLATES/README.md.template`
 
 ### 4.1 Generate `.chama.yml`
 
@@ -201,7 +217,7 @@ Create a contextual `CLAUDE.md` using the template as structural reference. Rule
 mkdir -p docs
 ```
 
-Create `docs/PROJECT_BRIEF.md` using `$CHAMA_TEMPLATES/PROJECT_BRIEF.md.template` as structural reference (if `$CHAMA_TEMPLATES` was found). If templates are not available, generate the brief from built-in knowledge following the 10-field contract. Must include all 10 fields from the synthesis. Use the current date.
+Create `docs/PROJECT_BRIEF.md` using `$CHAMA_TEMPLATES/PROJECT_BRIEF.md.template` as structural reference (if `$CHAMA_TEMPLATES` was found). If templates are not available, generate the brief from built-in knowledge following the 11-field contract. Must include all 11 fields from the synthesis. Use the current date.
 
 ### 4.4 Copy spec template
 
@@ -240,6 +256,45 @@ If `.gitignore` does not exist, generate one appropriate to the detected stack. 
 
 If `.gitignore` already exists, append only the `.chama/` entries if not already present.
 
+### 4.7 Generate `README.md`
+
+Create a `README.md` in the project root using `$CHAMA_TEMPLATES/README.md.template` as structural reference (if `$CHAMA_TEMPLATES` was found). If templates are not available, generate from built-in knowledge.
+
+**Rules:**
+- All content must be filled with project-specific text from the synthesis — never leave `{{...}}` placeholders.
+- **Quick Start** section must have real commands based on the detected stack:
+
+| Stack | Install | Run |
+|---|---|---|
+| Go | `go mod download` | `go run .` |
+| Node/React/Next.js | `npm install` | `npm start` or `npm run dev` |
+| Python | `pip install -r requirements.txt` | `python main.py` |
+| Rust | `cargo build` | `cargo run` |
+| Java/Spring | `./mvnw install` | `./mvnw spring-boot:run` |
+| Generic | _See component docs_ | _See component docs_ |
+
+- **Project Structure** section: use the directory tree from synthesis field #10.
+- **Development** section: include quality gates from components and Chama workflow commands.
+- **License** section: include only if the user chose a license (options 1-4 from field #11). Reference the license type (e.g., "This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details."). Omit the section entirely if the user chose "Nenhuma" (option 5).
+
+### 4.8 Generate `LICENSE`
+
+Generate `LICENSE` file based on synthesis field #11 (License choice). **Skip this step entirely if the user chose "Nenhuma" (option 5).**
+
+For each license type, generate the complete standard text with `{{YEAR}}` replaced by the current year and `{{AUTHOR}}` replaced by the git user name or GitHub owner:
+
+```bash
+YEAR=$(date +%Y)
+AUTHOR=$(git config user.name 2>/dev/null || echo "<author>")
+```
+
+**License content:**
+
+- **MIT**: Standard MIT License text (~170 words). Begin with `MIT License\n\nCopyright (c) {{YEAR}} {{AUTHOR}}`.
+- **Apache 2.0**: Standard Apache License 2.0 text. Begin with `Apache License\nVersion 2.0, January 2004`.
+- **GPL v3**: Include the standard GPL v3 preamble and reference the full text at https://www.gnu.org/licenses/gpl-3.0.txt. Begin with the standard header: `GNU GENERAL PUBLIC LICENSE\nVersion 3, 29 June 2007`.
+- **Proprietary**: Short proprietary notice: `Copyright (c) {{YEAR}} {{AUTHOR}}. All rights reserved.\n\nThis software is proprietary and confidential. Unauthorized copying, distribution, or use of this software, via any medium, is strictly prohibited.`
+
 ## Stage 5 — Summary + Optional Steps
 
 ### 5.1 Show tree
@@ -267,7 +322,7 @@ Ask the user sequentially (one at a time):
    If git is already initialized: "Deseja criar um commit com os artefatos gerados?"
    ```bash
    # Only add paths that actually exist to avoid pathspec errors
-   for f in .chama.yml CLAUDE.md docs/PROJECT_BRIEF.md .chama/ .gitignore; do
+   for f in .chama.yml CLAUDE.md docs/PROJECT_BRIEF.md .chama/ .gitignore README.md LICENSE; do
      [ -e "$f" ] && git add "$f"
    done
    # Add component directories from the synthesis (replace with actual paths)
@@ -329,6 +384,18 @@ When existing artifacts are detected (pre-check), the entire flow changes to pre
 #### `.gitignore`
 - If exists: only append missing `.chama/` entries
 - If not exists: create normally
+
+#### `README.md`
+1. If exists: read the existing file
+2. Compare sections — identify what's new in the generated version
+3. Propose adding only new sections or information
+4. Ask: "Manter existente / Adicionar seções novas / Ver diff?"
+
+#### `LICENSE`
+1. If exists: show the existing license type and the one from synthesis
+2. If different: ask "Manter licença existente / Substituir por <new>?"
+3. If same: skip silently
+4. If not exists: create normally (unless user chose "Nenhuma")
 
 #### Directory structure
 - Only create directories that don't exist yet

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -48,7 +48,7 @@ Analyze the prompt against the **11 mandatory fields** of the minimum contract (
 
 **Question count rules (field coverage is primary, word count is fallback):**
 - Prompt covers all 11 fields clearly → **0 questions** (skip to Stage 3)
-- Prompt covers most fields (7-9) → **1-2 questions** for missing fields
+- Prompt covers most fields (7-10) → **1-2 questions** for missing fields
 - Prompt covers some fields (4-6) → **3-4 questions** for missing fields
 - Prompt covers few fields (0-3) → **5 questions** for the most critical gaps
 
@@ -392,10 +392,10 @@ When existing artifacts are detected (pre-check), the entire flow changes to pre
 4. Ask: "Manter existente / Adicionar seções novas / Ver diff?"
 
 #### `LICENSE`
-1. If exists: show the existing license type and the one from synthesis
-2. If different: ask "Manter licença existente / Substituir por <new>?"
-3. If same: skip silently
-4. If not exists: create normally (unless user chose "Nenhuma")
+1. If exists and user chose a license (options 1-4): show the existing license type and the one from synthesis. If different: ask "Manter licença existente / Substituir por <new>?". If same: skip silently.
+2. If exists and user chose "Nenhuma" (option 5): ask "Existe um arquivo LICENSE. Deseja removê-lo?" — only remove with explicit confirmation.
+3. If not exists and user chose a license (options 1-4): create normally.
+4. If not exists and user chose "Nenhuma": skip silently.
 
 #### Directory structure
 - Only create directories that don't exist yet

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -217,7 +217,7 @@ Create a contextual `CLAUDE.md` using the template as structural reference. Rule
 mkdir -p docs
 ```
 
-Create `docs/PROJECT_BRIEF.md` using `$CHAMA_TEMPLATES/PROJECT_BRIEF.md.template` as structural reference (if `$CHAMA_TEMPLATES` was found). If templates are not available, generate the brief from built-in knowledge following the 11-field contract. Must include all 11 fields from the synthesis. Use the current date.
+Create `docs/PROJECT_BRIEF.md` using `$CHAMA_TEMPLATES/PROJECT_BRIEF.md.template` as structural reference (if `$CHAMA_TEMPLATES` was found). If templates are not available, generate the brief from built-in knowledge. Must include all synthesis fields that map to `docs/PROJECT_BRIEF.md` in the minimum contract table (fields #1-#10; the License field #11 is covered by `LICENSE` and `README.md`). Use the current date.
 
 ### 4.4 Copy spec template
 
@@ -285,14 +285,20 @@ For each license type, generate the complete standard text with `{{YEAR}}` repla
 
 ```bash
 YEAR=$(date +%Y)
-AUTHOR=$(git config user.name 2>/dev/null || echo "<author>")
+AUTHOR=$(git config user.name 2>/dev/null)
+if [ -z "$AUTHOR" ]; then
+  # Fallback: extract owner from git remote URL
+  REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+  AUTHOR=$(echo "$REMOTE_URL" | sed -E 's#.*[:/](.+)/.+(\.git)?#\1#')
+fi
+[ -z "$AUTHOR" ] && AUTHOR="<author>"
 ```
 
 **License content:**
 
 - **MIT**: Standard MIT License text (~170 words). Begin with `MIT License\n\nCopyright (c) {{YEAR}} {{AUTHOR}}`.
 - **Apache 2.0**: Standard Apache License 2.0 text. Begin with `Apache License\nVersion 2.0, January 2004`.
-- **GPL v3**: Include the standard GPL v3 preamble and reference the full text at https://www.gnu.org/licenses/gpl-3.0.txt. Begin with the standard header: `GNU GENERAL PUBLIC LICENSE\nVersion 3, 29 June 2007`.
+- **GPL v3**: Include the standard GPL v3 preamble (~600 words) and the "How to Apply" section. Do NOT include the full 35KB text — instead, reference it: "The complete license text is available at https://www.gnu.org/licenses/gpl-3.0.txt". Begin with the standard header: `GNU GENERAL PUBLIC LICENSE\nVersion 3, 29 June 2007`. This is the standard practice for most GPL v3 projects.
 - **Proprietary**: Short proprietary notice: `Copyright (c) {{YEAR}} {{AUTHOR}}. All rights reserved.\n\nThis software is proprietary and confidential. Unauthorized copying, distribution, or use of this software, via any medium, is strictly prohibited.`
 
 ## Stage 5 — Summary + Optional Steps

--- a/templates/README.md.template
+++ b/templates/README.md.template
@@ -1,0 +1,41 @@
+# {{PROJECT_NAME}}
+
+{{DESCRIPTION}}
+
+## Quick Start
+
+```bash
+git clone {{REPO_URL}}
+cd {{PROJECT_DIR}}
+{{INSTALL_CMD}}
+{{RUN_CMD}}
+```
+
+## Stack
+
+{{TECH_STACK}}
+
+## Project Structure
+
+```
+{{DIRECTORY_TREE}}
+```
+
+## Development
+
+### Quality Gates
+
+{{QUALITY_GATES}}
+
+### Workflow
+
+This project uses [Chama](https://github.com/rafaelportugal/chama) for SDLC orchestration:
+
+- `/chama:ideas` — brainstorm features
+- `/chama:architect` — generate specs from ideas
+- `/chama:code` — implement phases
+- `/chama:review-loop` — review and merge PRs
+
+## License
+
+{{LICENSE_SECTION}}

--- a/templates/README.md.template
+++ b/templates/README.md.template
@@ -36,6 +36,7 @@ This project uses [Chama](https://github.com/rafaelportugal/chama) for SDLC orch
 - `/chama:code` — implement phases
 - `/chama:review-loop` — review and merge PRs
 
+<!-- Omit this section entirely if the user chose "Nenhuma" (no license) -->
 ## License
 
 {{LICENSE_SECTION}}


### PR DESCRIPTION
Closes #52

## Spec
- #51

## Summary
Adiciona geração de `README.md` e `LICENSE` ao `/chama:new-project`. O README é público-facing com Quick Start baseado na stack. O LICENSE é gerado a partir de 5 opções apresentadas durante a concepção (MIT, Apache 2.0, GPL v3, Proprietary, Nenhuma).

### O que muda
- `templates/README.md.template` (novo) — referência estrutural para README
- `skills/new-project/SKILL.md` — campo #11 (License) na síntese, Steps 4.7 (README) e 4.8 (LICENSE), merge mode, pre-check, git add

### Pontos-chave
- Quick Start com comandos reais por stack (Go, Node, Python, Rust, Java)
- LICENSE sempre em inglês (padrão legal); README segue `project.language`
- Merge mode preserva README e LICENSE existentes
- Opção "Nenhuma" pula LICENSE e omite seção no README

## Checklist
- [x] README.md gerado com seções: nome, descrição, Quick Start, Stack, Structure, Development
- [x] Quick Start com comandos baseados na stack
- [x] `templates/README.md.template` criado
- [x] Pergunta de licenciamento com 5 opções explicadas
- [x] LICENSE gerado com conteúdo completo (MIT/Apache/GPL/Proprietary)
- [x] Opção "Nenhuma" não gera LICENSE e omite seção no README
- [x] Merge mode para README e LICENSE
- [x] Pre-check detecta README.md e LICENSE existentes
- [x] Stage 5 inclui README.md e LICENSE no git add
- [x] Referências atualizadas de 10 para 11 campos