### PR TITLE
fix: [Issue #72] Portable plugin discovery on macOS

### DIFF
--- a/workflow/scripts/chama-pipeline.sh
+++ b/workflow/scripts/chama-pipeline.sh
@@ -20,11 +20,17 @@ elif [[ -d "$ROOT_DIR/chama/workflow" ]]; then
 elif [[ -d "$HOME/.claude/plugins/chama/workflow" ]]; then
   CHAMA_DIR="$HOME/.claude/plugins/chama"
 else
-  # Search in Claude Code plugin cache (versioned path)
-  CHAMA_DIR=$(find "$HOME/.claude/plugins/cache/chama" -maxdepth 3 -name "chama-pipeline.sh" -printf '%h\n' 2>/dev/null | sort -V | tail -1)
-  if [[ -n "$CHAMA_DIR" ]]; then
-    CHAMA_DIR="${CHAMA_DIR%/workflow/scripts}"
-  else
+  # Search in Claude Code plugin cache (versioned path).
+  # Real layout is $CACHE_ROOT/chama/<version>/workflow/scripts/chama-pipeline.sh (5 levels).
+  # Uses POSIX find (no -printf) so it works on macOS BSD find and GNU find alike.
+  # Stderr is intentionally not suppressed so real errors (e.g. permission denied) stay visible.
+  CACHE_ROOT="$HOME/.claude/plugins/cache/chama"
+  CHAMA_DIR=""
+  if [[ -d "$CACHE_ROOT" ]]; then
+    CHAMA_DIR=$(find "$CACHE_ROOT" -maxdepth 5 -name "chama-pipeline.sh" | sort -V | tail -1)
+    CHAMA_DIR="${CHAMA_DIR%/workflow/scripts/chama-pipeline.sh}"
+  fi
+  if [[ -z "$CHAMA_DIR" ]]; then
     echo "ERROR: chama plugin not found (local or global)." >&2
     echo "Searched: $ROOT_DIR/workflow, $ROOT_DIR/chama/, ~/.claude/plugins/chama/, ~/.claude/plugins/cache/chama/" >&2
     exit 1


### PR DESCRIPTION
Closes #72

## Spec
- #71

## Summary

Fix `workflow/scripts/chama-pipeline.sh` plugin discovery to work on macOS (BSD `find`) while preserving Linux behavior. The script was failing silently on macOS because:

1. `find -printf '%h\n'` is GNU-only. BSD `find` rejects it with `find: -printf: unknown primary or operator`, the error was masked by `2>/dev/null`, and `CHAMA_DIR` ended up empty — leading to a silent `exit 1`.
2. `-maxdepth 3` was also insufficient for the real cache layout (`$CACHE_ROOT/chama/<version>/workflow/scripts/chama-pipeline.sh` = 5 levels). This second bug was latent, masked by the `-printf` failure; discovered during manual validation of the happy path.

### Changes
- Replace `find -printf '%h\n'` with POSIX `find` + parameter expansion `${CHAMA_DIR%/workflow/scripts/chama-pipeline.sh}`.
- Guard the `find` call with `[[ -d "$CACHE_ROOT" ]]` so the happy path on machines without a cache dir stays quiet.
- Remove `2>/dev/null` on the `find` so real errors (permission denied, etc.) stay visible.
- Bump `-maxdepth` from `3` to `5` to match the actual cache layout.

Discovery precedence (repo → `chama/` subdir → legacy global → versioned cache) and semver-aware version selection (`sort -V | tail -1`) are preserved.

## Checklist
- [x] `-printf '%h\n'` removed from executable code (workflow/scripts/chama-pipeline.sh).
- [x] Parameter expansion uses `${CHAMA_DIR%/workflow/scripts/chama-pipeline.sh}`.
- [x] Guard `[[ -d "$CACHE_ROOT" ]]` protects the `find` call.
- [x] `2>/dev/null` removed from discovery `find` (real errors now visible).
- [x] Discovery precedence of the 4 branches preserved.
- [x] `bash -n workflow/scripts/chama-pipeline.sh` passes.
- [x] Manual validation on macOS (Darwin 24.1.0, zsh): happy path, multi-version selection, missing cache, missing plugin everywhere, precedence branch 2 > branch 4.
- [ ] Manual validation on Linux — deferred to CI or follow-up (not available locally).

## Manual validation results (macOS)

| Scenario | Expected | Observed |
|----------|----------|----------|
| Plugin only in cache | `CHAMA_DIR` resolves to `.../1.7.5` | ✅ |
| Multiple versions in cache | `1.7.5` selected over `1.7.3`/`1.7.4` | ✅ |
| Cache dir missing | guard skips `find`, error lists 4 paths | ✅ |
| No plugin anywhere | clear error on stderr, `exit 1` | ✅ |
| `chama/` subdir present | branch 2 wins, cache ignored | ✅ |

## Notes on the `-maxdepth` bump

Originally I planned to touch only the `-printf` portability issue as listed in the phase checklist. During manual validation (Test 4, happy path on macOS with plugin only in the cache), I discovered the resolved `CHAMA_DIR` was empty even after the `-printf` fix. Root cause: `-maxdepth 3` can't reach `chama-pipeline.sh` at depth 5.

Without this second fix the Spec's success criterion (`MAX_TASKS=1 chama-compose` runs on macOS with plugin only in the cache) can't be met, so I included it in the same commit and documented the finding here and in the commit message. If the maintainer prefers a separate commit/PR, I'll split it.