### PR TITLE
fix: [Issue #73] Auditoria de portabilidade dos scripts shell

### DIFF
--- a/scripts/resolve-spec-template.sh
+++ b/scripts/resolve-spec-template.sh
@@ -17,8 +17,8 @@ else
     CHAMA_PLUGIN_DIR="chama"
   elif [ -d "$HOME/.claude/plugins/chama/templates" ]; then
     CHAMA_PLUGIN_DIR="$HOME/.claude/plugins/chama"
-  elif CACHE_HIT=$(find "$HOME/.claude/plugins/cache/chama" -maxdepth 4 -name "spec.md.default" -printf '%h\n' 2>/dev/null | sort -V | tail -1) && [ -n "$CACHE_HIT" ]; then
-    CHAMA_PLUGIN_DIR="${CACHE_HIT%/templates}"
+  elif CACHE_HIT=$([ -d "$HOME/.claude/plugins/cache/chama" ] && find "$HOME/.claude/plugins/cache/chama" -maxdepth 5 -name "spec.md.default" | sort -V | tail -1) && [ -n "$CACHE_HIT" ]; then
+    CHAMA_PLUGIN_DIR="${CACHE_HIT%/templates/spec.md.default}"
   else
     echo "ERROR: Could not find chama plugin directory" >&2
     exit 1


### PR DESCRIPTION
Closes #73

## Spec
- #71

## Summary
Auditoria de portabilidade POSIX em todos os scripts shell do repo, com correção do único finding crítico encontrado.

## Audit Report

### Comandos executados
```bash
# Padrões GNU-only
rg -n -- '-printf|-regextype|readlink -f|grep -P|date -d ' --glob '*.sh'

# sed -i sem sufixo (incompatível macOS)
rg -n -- "sed -i(?!\s+['\"])" --glob '*.sh'

# find -not (não POSIX)
rg -n -- 'find .+ -not\b' --glob '*.sh'

# maxdepth insuficiente
rg -n -- 'maxdepth [0-4] ' --glob '**/*.sh'
```

### Findings

| # | Arquivo | Linha | Padrão | Decisão |
|---|---------|-------|--------|---------|
| 1 | `scripts/resolve-spec-template.sh` | 20 | `-printf '%h\n'` (GNU-only) | **FIX** — mesmo bug do PR #74 |
| 2 | `workflow/scripts/chama-pipeline.sh` | 25 | `-printf` em comentário | Falso-positivo — apenas texto do comentário explicativo |
| 3 | `scripts/prototype-screenshot.sh` | 37 | `maxdepth 1` | OK — intencional (busca local no dir) |

### Correção aplicada (Finding #1)

`scripts/resolve-spec-template.sh:20`:
- `-printf '%h\n'` → POSIX `find` + parameter expansion `${CACHE_HIT%/templates/spec.md.default}`
- Guard `[ -d ... ]` antes do `find`
- `-maxdepth 4` → `-maxdepth 5` (match do layout real do cache)

### Padrões NÃO encontrados
- `sed -i` sem sufixo: 0 ocorrências
- `grep -P`: 0 ocorrências
- `readlink -f`: 0 ocorrências
- `-regextype`: 0 ocorrências
- `find -not`: 0 ocorrências
- `date -d`: 0 ocorrências

### Conclusão
Apenas 1 finding crítico (já corrigido). Nenhuma issue adicional necessária.

## Checklist
- [x] Relatório de auditoria presente na descrição da PR
- [x] Comandos usados na auditoria documentados para reprodutibilidade
- [x] Finding crítico corrigido (resolve-spec-template.sh)
- [x] `bash -n scripts/*.sh` passa em todos os scripts
- [x] Nenhum finding não-crítico pendente (nenhuma issue adicional criada)